### PR TITLE
misc fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY requirements.txt  .
 RUN  pip3 install -r requirements.txt
 
 # Copy function code
-COPY main.py /app/
+COPY *.py /app/
 COPY src/ /app/src
 
 

--- a/src/Dashboard.py
+++ b/src/Dashboard.py
@@ -15,7 +15,7 @@ class Dashboard:
         self.parsePanels(json['dashboard']['panels'])
 
 
-    # For collapse = true , you have to put rows panels inside the row definition , in panels[ ] section.
+    # For collapse = true, you have to put rows panels inside the row definition , in panels[ ] section.
     # For collapse = false, you have to put rows panels below the row definition.
     def parsePanels(self, panels):
         page = Page(conversionService=self.conversionService, widgets=[])

--- a/src/Grafana.py
+++ b/src/Grafana.py
@@ -11,7 +11,7 @@ class Grafana:
         self.apiKey = config['grafana']['apiKey']
         self.host = config['grafana']['host']
         self.createOutputDir()
-        self.dahboardsPaths = []
+        self.dashboardsPaths = []
 
         # Initialize Grafana API
         print("Connecting to Grafana API")
@@ -33,13 +33,15 @@ class Grafana:
         dashboardHeaders = ['id', 'title', 'tags', 'isStarred', 'url']
 
         print('\n')
-        dashboards = questionary.checkbox('Select the Grafana Dashboards you woul like to migrate (based on dashboards URLs):', choices=[elem['url'] for elem in dashboardData]).ask()
+        dashboards = questionary.checkbox(
+            'Select the Grafana Dashboards you would like to migrate (based on dashboards URLs):',
+            choices=[elem['url'] for elem in dashboardData]).ask()
         # Keep only selected dashboards
         dashboardData = [elem for elem in dashboardData if elem['url'] in dashboards]
         
         self.saveToOutput(dashboardData, dashboardHeaders)
-        return self.dahboardsPaths
-        
+        return self.dashboardsPaths
+
     def saveToOutput(self, dashboardData, dashboardHeaders):
         dashboardList = []
         for dashboard in dashboardData:

--- a/src/Grafana.py
+++ b/src/Grafana.py
@@ -73,7 +73,7 @@ class Grafana:
         for dashboard in dashboardData:
             content = self.grafana_api.dashboard.get_dashboard(dashboard['uid'])
             dashboardPath = f'{constants.GRAFANA_OUTPUT_DIR}/%s-%s.json' % (dashboard['uid'], dashboard['uri'].replace('db/', ''))
-            self.dahboardsPaths.append(dashboardPath)
+            self.dashboardsPaths.append(dashboardPath)
             # Write dashboard json to output directory
             with open(dashboardPath, 'w') as f:
                 f.write(json.dumps(content, indent=4, sort_keys=True))

--- a/src/NewRelic.py
+++ b/src/NewRelic.py
@@ -28,7 +28,12 @@ class NewRelic:
         # Read file
         with open(grafanaDashboard, 'r') as f:
             data = json.load(f)
-        
+
+        # Some dashboards we get may not be wrapped in parent "dashboard" json
+        # We will convert those to the schema we expect
+        if 'dashboard' not in data:
+            data = {"dashboard": data}
+
         # Conversion service
         variables = Dashboard.getVariables(data)
         promQL2NrqlService = PromQL2NrqlService(self.config, variables)

--- a/src/PromQL2NrqlService.py
+++ b/src/PromQL2NrqlService.py
@@ -48,9 +48,15 @@ class PromQL2NrqlService:
                 "endTime": "null",
                 "step": 30
             })
-            # Remove `Facet Dimensions()`
-            newNrql = self.removeDimensions(nrql.json()['nrql'])
-            self.cache[promql] = newNrql
+
+            if nrql.status_code == 200:
+                # Remove `Facet Dimensions()`
+                newNrql = self.removeDimensions(nrql.json()['nrql'])
+                self.cache[promql] = newNrql
+            else:
+                # Print the error to console
+                print('{}:\n    {}'.format(nrql.json()['message'], promql))
+                self.cache[promql] = promql
 
         return self.cache[promql]
 

--- a/src/Widget.py
+++ b/src/Widget.py
@@ -46,6 +46,12 @@ class Widget:
                 if 'options' in widget and 'fieldOptions' in widget['options'] and 'defaults' in widget['options']['fieldOptions'] and 'max' in widget['options']['fieldOptions']['defaults']:
                     limit = widget['options']['fieldOptions']['defaults']['max']
 
+            # We don't know how to convert these so just remove them
+            if 'cards' in widget:
+                del widget['cards']
+            if 'datasource' in widget:
+                del widget['datasource']
+
             elif self.panelType == 'table':
                 self.visualisation = "viz.table"
             elif self.panelType == 'text':

--- a/test-queries.py
+++ b/test-queries.py
@@ -85,6 +85,6 @@ dashboards = os.listdir('output/dashboards')
 for file in dashboards:
 	parse(file)
 
-# Outpust errors to json
+# Output errors to json
 with open('query-errors.json', 'w') as f:
     f.write(json.dumps(errors, indent=4, sort_keys=True))


### PR DESCRIPTION
* grammar fixes
* exclude some items in widgets which we know will cause issues with the translate service
* slightly better exception handling
  * cache errors and print them to the console

Right now almost all conversion exceptions are hidden from the end user.  The exceptions are written to the resulting json dashboard.  When you run the conversion everything looks OK and there are no warnings but what is generated is a dashboard which cannot be used - it's invalid.  Example below.
```
    "rawConfiguration": {
        "text": "{\"exception\": \"KeyError\", \"arguments\": [\"content\"]}"
    },
    "title": "About this dashboard",
    "visualization": {
        "id": "viz.markdown"
    }
```

If the `'https://promql-gateway.service.newrelic.com/api/v1/translate'` service does not respond with a 200 status code, write the exception to the console.  At least this way end users will be aware of failures.   
Also - add those to the cache.json so we do not retry to send untranslatable data to the service.

Example new output:
```
Converting to dashboard format
Starting Conversion: argocd.json
Failed to parse PromQL:
    sum(round(increase(argocd_app_sync_total{}[$interval]))) by ($grouping)
```

Signed-off-by: smcavallo <smcavallo@hotmail.com>