### PR TITLE
(feat): local mode support

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,10 +26,10 @@ for opt, arg in options:
         token = os.getenv('NEW_RELIC_API_TOKEN')
         accountId = os.getenv('NEW_RELIC_ACCOUNT_ID')
         localConfig = defaultConfig()
-        config['api']['userKey'] = token
-        config['api']['accountId'] = accountId
+        localConfig['api']['userKey'] = token
+        localConfig['api']['accountId'] = accountId
         # New Relic
-        newRelic = NewRelic(config)
+        newRelic = NewRelic(localConfig)
         # Process the dashboard files on disk
         grafanaDashboardsFiles = glob.glob(os.path.join(constants.GRAFANA_OUTPUT_DIR, "*.json"))
         for file in grafanaDashboardsFiles:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,14 @@
-from src.config.config import config
-from src.utils.utils import banner
+import getopt
+import glob
+import os
+import sys
+
+from src.Crossplane import Crossplane
 from src.Grafana import Grafana
 from src.NewRelic import NewRelic
+from src.config.config import config, defaultConfig
+from src.utils.utils import banner
+import src.utils.constants as constants
 
 #############################################################################
 ######                             main                               #######
@@ -9,14 +16,42 @@ from src.NewRelic import NewRelic
 
 banner()
 
-config = config()
+options, remainder = getopt.getopt(sys.argv[1:], 'l:c', ['local',
+                                                         'crossplane',
+                                                         ])
+for opt, arg in options:
+    if opt in ('-l', '--local'):
+        # In local mode we just read the grafana files from a directory
+        # instead of downloading them from the grafana api
+        token = os.getenv('NEW_RELIC_API_TOKEN')
+        accountId = os.getenv('NEW_RELIC_ACCOUNT_ID')
+        localConfig = defaultConfig()
+        config['api']['userKey'] = token
+        config['api']['accountId'] = accountId
+        # New Relic
+        newRelic = NewRelic(config)
+        # Process the dashboard files on disk
+        grafanaDashboardsFiles = glob.glob(os.path.join(constants.GRAFANA_OUTPUT_DIR, "*.json"))
+        for file in grafanaDashboardsFiles:
+            nrDashboard = newRelic.convert(file)
+    elif opt in ('-c', '--crossplane'):
+        # In crossplane mode we read newrelic dashboard files and convert them to
+        # the format required by the crossplane newrelic operator
+        # https://marketplace.upbound.io/providers/smcavallo/provider-newrelic/v0.1.0
+        crossplane = Crossplane()
+        nrDashboardsFiles = glob.glob(os.path.join(constants.NEWRELIC_OUTPUT_DIR, "*.json"))
+        for file in nrDashboardsFiles:
+            crossplane.convert(file)
 
-# Grafana
-grafana = Grafana(config)
-grafanaDashboardsFiles = grafana.selectGrafanaDashboards()
+if not options:
+    config = config()
 
-# New Relic
-newRelic = NewRelic(config)
-for file in grafanaDashboardsFiles:
-    nrDashboard = newRelic.convert(file)
-    newRelic.importDashboard(nrDashboard)
+    # Grafana
+    grafana = Grafana(config)
+    grafanaDashboardsFiles = grafana.selectGrafanaDashboards()
+
+    # New Relic
+    newRelic = NewRelic(config)
+    for file in grafanaDashboardsFiles:
+        nrDashboard = newRelic.convert(file)
+        newRelic.importDashboard(nrDashboard)

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,5 @@ websockets==10.4
 wrapt==1.14.1
 yarl==1.8.1
 zipp==3.10.0
+
+PyYAML~=6.0

--- a/src/Crossplane.py
+++ b/src/Crossplane.py
@@ -15,7 +15,8 @@ class Crossplane:
 
         for pages in data['pages']:
             for widget in pages['widgets']:
-                del widget['id']
+                if 'id' in widget:
+                    del widget['id']
                 if 'text' in widget['rawConfiguration']:
                     widget["visualization"]['id'] = "viz.markdown"
                 else:

--- a/src/Crossplane.py
+++ b/src/Crossplane.py
@@ -1,0 +1,45 @@
+import json
+import os
+import yaml
+import src.utils.constants as constants
+
+
+class Crossplane:
+
+    def convert(self, nrDashboard):
+        provider_name = "newrelic-provider"
+
+        # Read file
+        with open(nrDashboard, 'r') as f:
+            data = json.load(f)
+
+        for pages in data['pages']:
+            for widget in pages['widgets']:
+                del widget['id']
+                if 'text' in widget['rawConfiguration']:
+                    widget["visualization"]['id'] = "viz.markdown"
+                else:
+                    widget["visualization"]['id'] = "viz.line"
+
+        pre, ext = os.path.splitext(nrDashboard)
+        dashboardJson = {
+            "apiVersion": "dashboard.provider-newrelic.crossplane.io/v1alpha1",
+            "kind": "Dashboard",
+            "metadata": {"name": os.path.basename(pre).lower()},
+            "spec": {
+                "deletionPolicy": "Delete",
+                "forProvider": data,
+                "providerConfigRef": {
+                    "name": provider_name
+                }
+            }}
+
+        # Create yaml
+        output = yaml.dump(dashboardJson, default_flow_style=False)
+        # Write out file
+        filePath = f"{constants.NEWRELIC_OUTPUT_DIR}/crossplane-%s.yaml" % os.path.basename(pre)
+        f = open(filePath, "w")
+        f.write(output)
+        f.close()
+
+        return filePath

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -4,28 +4,33 @@ from pathlib import Path
 from src.utils.utils import isNumber
 import src.utils.constants as constants
 
-def createConfigFile(ConfigFileName):
-    config = {
+
+def defaultConfig():
+    return {
         "auth": {
             "ssoEnabled": False,
-            "sso":{
-                "browserCookie":"",
+            "sso": {
+                "browserCookie": "",
             },
-            "nonSso":{
+            "nonSso": {
                 "username": "",
                 "password": "",
             }
         },
         "api": {
             "userKey": "",
-            "accountId":""
+            "accountId": ""
         },
         "grafana": {
             "apiKey": "",
             "host": ""
         }
     }
-    
+
+
+def createConfigFile(ConfigFileName):
+    config = defaultConfig()
+
     print("")
     questionary.print("Let's get some information about New Relic (destination) 🔑", style="bold italic fg:darkred")
     ssoEnabled = questionary.confirm("Do you use SSO to login to New Relic?").ask()


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

This PR adds support for local mode (`--local`) where you do not need a grafana instance to convert dashboards.
Example - https://github.com/aws/karpenter/tree/main/website/content/en/preview/getting-started/getting-started-with-eksctl

With this change you can download the grafana dashboards from that repository to disk and run this converter to output new relic dashboards.

Also added is support  (`--crossplane`) to convert the dashboards into the format required by the crossplane `provider-newrelic` to be able to add/update/delete/manage your dashboards through a kubernetes operator.
See - https://marketplace.upbound.io/providers/smcavallo/provider-newrelic/v0.1.0
