### PR TITLE
Hacks and fixes to convert dashboards for NI PoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ config.json
 
 # Query cache file
 cache.json
+
+.venv

--- a/src/Grafana.py
+++ b/src/Grafana.py
@@ -15,7 +15,7 @@ class Grafana:
 
         # Initialize Grafana API
         print("Connecting to Grafana API")
-        self.grafana_api = GrafanaFace(auth=self.apiKey, host=self.host, protocol='https')
+        self.grafana_api = GrafanaFace(auth=self.apiKey, host=self.host, protocol='https', timeout=20.0)
     
     def createOutputDir(self):
         # Create output directory if it doesn't exist

--- a/src/Widget.py
+++ b/src/Widget.py
@@ -6,7 +6,7 @@ class Widget:
     def __init__(self, conversionService, widget):
         self.conversionService = conversionService
         self.id = widget['id']
-        self.title = widget['title']
+        self.title = widget.get('title', '')
         self.panelType = widget['type']
 
         # Coordinate conversion
@@ -45,10 +45,16 @@ class Widget:
 
                 if 'options' in widget and 'fieldOptions' in widget['options'] and 'defaults' in widget['options']['fieldOptions'] and 'max' in widget['options']['fieldOptions']['defaults']:
                     limit = widget['options']['fieldOptions']['defaults']['max']
+
+                # HACK: insert arbitrary value for required "limit" field.
+                # Grafana has an option to detect a maximum value.
+                limit = limit if limit else 1000
             elif self.panelType == 'table':
                 self.visualisation = "viz.table"
             elif self.panelType == 'text':
                 self.visualisation = "viz.markdown"
+            elif self.panelType == 'piechart':
+                self.visualisation = 'viz.pie'
 
             if self.visualisation is None:
                 # No idea what to do with this


### PR DESCRIPTION
Several edits to get NI's Grafana dashboards working for NewRelic PoC:
* Add `.venv` to `.gitignore` to make it easier to work in a virtual environment.
* Increase timeout to `20s` instead of `5s`.
* Get `userKey` from `config` if it's not present in environment.
   * Is this correct? Fixed my login for non-SSO with user API key.
* Apply hack fix to "must have a range vector" conversion error.
* Throw exception when conversion fails so that a text error widget is created instead of an invalid dashboard.
* Handle "no title" case by inserting empty title.
* Add arbitrary limit of `1000` so that `bullet` charts without a `limit` don't fail import.
* Add support for `viz.pie` chart.

# Testing Done

Imported one dashboard!